### PR TITLE
MooseX::Declare dependency

### DIFF
--- a/t/catch_isa.t
+++ b/t/catch_isa.t
@@ -1,14 +1,22 @@
 use Test::Spec;
 require Test::NoWarnings;
-use MooseX::Declare;
 
 use syntax 'try';
 
 # mock classes inheritance for tests
-class Mock::Animal                          { }
-class Mock::Bird    extends Mock::Animal    { }
-class Mock::Raptor  extends Mock::Bird      { }
-class Mock::Eagle   extends Mock::Raptor    { }
+package Mock::Animal;
+sub new { bless {}, shift };
+
+package Mock::Bird;
+use base 'Mock::Animal';
+
+package Mock::Raptor;
+use base 'Mock::Bird';
+
+package Mock::Eagle;
+use base 'Mock::Raptor';
+
+package main;
 
 sub test_catch_bird {
     my ($err, $expected_result) = @_;


### PR DESCRIPTION
First of all, thanks for contributing such a high quality module to the cpan.

But its installation could be speeded up by getting rid of MooseX::Declare as a dependency. Also sometimes Devel::Declare, that MooseX::Declare depends on, is a little bit dodgy to install under strawberry perl for windows.

Because you are using MooseX::Declare only in a single test, I was able to remove it and use builtin perl mechanism instead. 
